### PR TITLE
Update Order.php

### DIFF
--- a/inc/Order.php
+++ b/inc/Order.php
@@ -487,11 +487,11 @@ class Order extends BaseEntity{
 					break;
 				
 				case 'item_tax' :
-					array_push ( $data, $item['line_tax'] );
+					array_push ( $data, number_format( floatval( $item['line_tax'] ), 2, '.', ',' ) );
 					break;
 				
 				case 'item_total' :
-					array_push ( $data, $item['line_total'] );
+					array_push ( $data, number_format( ( floatval( $item['line_subtotal'] ) + floatval( $item['line_tax'] ) ), 2, '.', ',' ) );
 					break;
 				
 				case 'item_variation' :


### PR DESCRIPTION
Fix for "item price incl. tax" bug reported on WP support forum.
Fix for "item price incl. tax" and "item tax" rounding